### PR TITLE
Fix CI

### DIFF
--- a/libffi-rs/src/high/closures/structs.rs
+++ b/libffi-rs/src/high/closures/structs.rs
@@ -423,11 +423,7 @@ mod test {
     #[test]
     fn closure_can_unwind() {
         let result = std::panic::catch_unwind(|| {
-            #[expect(
-                clippy::unused_unit,
-                reason = "`Closure` is unable to find the correct trait implementation without `-> ()`"
-            )]
-            let closure = Closure::new_unwindable(|| -> () { panic!("Test") }).unwrap();
+            let closure: Closure<_, (), _> = Closure::new_unwindable(|| panic!("Test")).unwrap();
 
             (closure.as_fn_ptr())();
         });

--- a/libffi-rs/src/middle/arg.rs
+++ b/libffi-rs/src/middle/arg.rs
@@ -89,7 +89,7 @@ impl<'arg> Arg<'arg> {
 
 /// Create a new borrowed `Arg`.
 #[deprecated = "Use `Arg::borrowed` instead. This function will be removed in a future version."]
-pub fn arg<T>(arg: &T) -> Arg {
+pub fn arg<T>(arg: &T) -> Arg<'_> {
     Arg::borrowed(arg)
 }
 

--- a/libffi-rs/src/middle/builder.rs
+++ b/libffi-rs/src/middle/builder.rs
@@ -188,7 +188,7 @@ impl Builder {
         self,
         callback: super::Callback<U, R>,
         userdata: &U,
-    ) -> Result<super::Closure, Error> {
+    ) -> Result<super::Closure<'_>, Error> {
         super::Closure::new(self.into_cif()?, callback, userdata)
     }
 
@@ -211,7 +211,7 @@ impl Builder {
         self,
         callback: super::CallbackMut<U, R>,
         userdata: &mut U,
-    ) -> Result<super::Closure, Error> {
+    ) -> Result<super::Closure<'_>, Error> {
         super::Closure::new_mut(self.into_cif()?, callback, userdata)
     }
 

--- a/libffi-rs/src/middle/mod.rs
+++ b/libffi-rs/src/middle/mod.rs
@@ -553,7 +553,7 @@ mod test {
 
     macro_rules! gen_identity_fn_test {
         ($fn:ident($ty:ty = $val:expr, $ffity:expr)) => {{
-            let cif = Cif::new(&[$ffity], Some($ffity)).unwrap();
+            let cif = Cif::new(std::slice::from_ref(&$ffity), Some($ffity)).unwrap();
             let orig: $ty = $val;
             // SAFETY: It is assumed that $fn is a valid function accepting $ty and returning $ty.
             let result: $ty = unsafe {


### PR DESCRIPTION
* Define the `RET` type argument to `high::Closure` instead of explicitly stating that the closure returns `()`.
* Use `std::slice::from_ref` in `gen_identity_fn_test` for `middle`'s tests. (`clippy::cloned_ref_to_slice_refs`)