### PR TITLE
Fix qsort example

### DIFF
--- a/QSORT.md
+++ b/QSORT.md
@@ -46,10 +46,10 @@ unsafe extern "C" fn compare_i32s(
 ) {
     // This function accepts a two pointers to `i32`s and returns a `i32`.
     unsafe {
-        let args: *const *const *const i32 = args.cast();
-        let arg_a = **args; // a pointer to the first `i32` to compare.
+        // a pointer to the first `i32` to compare.
+        let arg_a: *const i32 = *((*(args)).cast::<*const i32>());
         // We need to add 1 to get the next pointer in the argument array.
-        let arg_b = *((*args).add(1)); // a pointer to the second `i32` to compare.
+        let arg_b: *const i32 = *((*(args.add(1))).cast::<*const i32>());
 
         (*result).write(match (*arg_a).cmp(&*arg_b) {
             std::cmp::Ordering::Less => -1,
@@ -100,7 +100,7 @@ fn main() -> Result<(), Error> {
         prep_cif(
             &raw mut cmp_cif,
             ffi_abi_FFI_DEFAULT_ABI,
-            1,
+            2,
             &raw mut types::sint32,
             cmp_args.as_mut_ptr(),
         )?;

--- a/QSORT.md
+++ b/QSORT.md
@@ -37,7 +37,10 @@ unsafe extern "C" {
 // The function provided to `qsort` to compare two `i32`s
 unsafe extern "C" fn compare_i32s(
     _cif: &ffi_cif,
-    result: *mut mem::MaybeUninit<i32>,
+    // Libffi expects at least a full register to be written to `result`. If a `i32` is written,
+    // the comparison may fail on big endian targets. Since -1 is all 1's in two's complement,
+    // writing -1, 0, or 1 should work for all targets.
+    result: *mut mem::MaybeUninit<isize>,
     args: *const *const c_void,
     userdata: *const (),
 ) {


### PR DESCRIPTION
The qsort example was broken on several architectures due to multiple issues:

* It did not write a full register width with the result.
* The cif for the comparison function was initialized with 1 arguments instead of 2.
* Wrong order of pointer dereferencing and addition.