### PR TITLE
Add test for default ABI

### DIFF
--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -238,12 +238,10 @@ mod powerpc_family {
         pub const ffi_abi_FFI_LINUX: ffi_abi = 0b00_1000;
 
         mod elfv1 {
-            pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = 0b0;
             pub const FFI_TRAMPOLINE_SIZE: usize = 24;
         }
 
         mod elfv2 {
-            pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = super::ffi_abi_FFI_LINUX_STRUCT_ALIGN;
             pub const FFI_TRAMPOLINE_SIZE: usize = 32;
         }
 
@@ -275,7 +273,6 @@ mod powerpc_family {
         }
 
         pub use elf::FFI_TRAMPOLINE_SIZE;
-        use elf::STRUCT_ALIGN_FLAG;
 
         mod long_double_64 {
             pub const LONG_DOUBLE_128_FLAG: crate::ffi_abi = 0b0;
@@ -295,7 +292,7 @@ mod powerpc_family {
         use long_double_128::LONG_DOUBLE_128_FLAG;
 
         pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi =
-            ffi_abi_FFI_LINUX | STRUCT_ALIGN_FLAG | LONG_DOUBLE_128_FLAG;
+            ffi_abi_FFI_LINUX | ffi_abi_FFI_LINUX_STRUCT_ALIGN | LONG_DOUBLE_128_FLAG;
 
         pub const FFI_NATIVE_RAW_API: u32 = 0;
         pub const FFI_GO_CLOSURES: u32 = 1;

--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -364,3 +364,22 @@ mod sparc64 {
 
 #[cfg(target_arch = "sparc64")]
 pub use sparc64::*;
+
+#[cfg(all(test, not(miri)))]
+mod test {
+    use core::ffi::c_uint;
+
+    use super::*;
+
+    // Disable test when performing dynamic linking to libffi until version 3.5.0 is required by
+    // libffi-rs.
+    #[cfg(not(feature = "system"))]
+    #[test]
+    fn verify_default_abi() {
+        unsafe extern "C" {
+            safe fn ffi_get_default_abi() -> c_uint;
+        }
+
+        assert_eq!(ffi_abi_FFI_DEFAULT_ABI, ffi_get_default_abi())
+    }
+}


### PR DESCRIPTION
Libffi v3.5.0 added a new `ffi_get_default_abi` function that returns the default ABI. A new test was added to ensure that the default abi set by libffi-rs is identical to the one used when compiling libffi.

This test is disabled when using the system libffi as it is not currently required to use libffi v3.5.0.