### PR TITLE
Add test to verify `low::closure_alloc` behavior

### DIFF
--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -1472,4 +1472,22 @@ mod test {
             return_large_struct
         );
     }
+
+    // Disable test when performing dynamic linking to libffi until version 3.5.0 is required by
+    // libffi-rs.
+    #[cfg(not(feature = "system"))]
+    #[test]
+    fn verify_closure_alloc_asks_for_sufficient_space() {
+        // `closure_alloc` allocates `mem::size_of::<ffi_closure>()` bytes. Libffi-rs does not
+        // necessarily have the correct size of `ffi_closure`, as the size could differ depending
+        // on compilation options and architecture. However, the `ffi_closure` defined in libffi-rs
+        // should always be at least as large as libffi's and `closure_alloc` should therefore
+        // allocate enough space. This test verifies that assumption.
+
+        unsafe extern "C" {
+            safe fn ffi_get_closure_size() -> usize;
+        }
+
+        assert!(size_of::<ffi_closure>() >= ffi_get_closure_size());
+    }
 }


### PR DESCRIPTION
`low::closure_alloc` should always allocate sufficient space for libffi's `ffi_closure`. However, libffi-rs does not have access to the actual `ffi_closure` definition, so this test checks that sufficient space is allocated in `low::closure_alloc`.